### PR TITLE
Fix broken GitHub Action due to GitHub update

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -24,7 +24,7 @@ jobs:
           - { name: linux-python3.12           , requirements: pinned ,  python-ver: "3.12", os: ubuntu-latest }
           - { name: windows-python3.7-minimum  , requirements: minimum,  python-ver: "3.7" , os: windows-latest }
           - { name: windows-python3.12         , requirements: pinned ,  python-ver: "3.12", os: windows-latest }
-          - { name: macos-python3.7-minimum    , requirements: minimum,  python-ver: "3.7" , os: macos-latest }
+          - { name: macos-python3.7-minimum    , requirements: minimum,  python-ver: "3.7" , os: macos-13 }
           - { name: macos-python3.12           , requirements: pinned ,  python-ver: "3.12", os: macos-latest }
     steps:
       - name: Checkout repo


### PR DESCRIPTION
The error was `The version '3.7' with architecture 'arm64' was not found for macOS 14.4.1`. GitHub recently updated the `macos-latest` environment to `macos-14-arm64`, and Python 3.9 and earlier aren't available there.

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-ai/blob/main/docs/CONTRIBUTING.rst)?
- [x] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?