### PR TITLE
Add column for storing visualization embeddings

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,11 +21,11 @@ jobs:
       matrix:
         include:
           - { name: linux-python3.10-minimum   , requirements: minimum,  python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.14           , requirements: pinned ,  python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.13           , requirements: pinned ,  python-ver: "3.13", os: ubuntu-latest }
           - { name: windows-python3.10-minimum , requirements: minimum,  python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.14         , requirements: pinned ,  python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.13         , requirements: pinned ,  python-ver: "3.13", os: windows-latest }
           - { name: macos-python3.10-minimum   , requirements: minimum,  python-ver: "3.10", os: macos-13 }
-          - { name: macos-python3.14           , requirements: pinned ,  python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.13           , requirements: pinned ,  python-ver: "3.13", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.7-minimum    , requirements: minimum,  python-ver: "3.7" , os: ubuntu-latest }
-          - { name: linux-python3.12           , requirements: pinned ,  python-ver: "3.12", os: ubuntu-latest }
-          - { name: windows-python3.7-minimum  , requirements: minimum,  python-ver: "3.7" , os: windows-latest }
-          - { name: windows-python3.12         , requirements: pinned ,  python-ver: "3.12", os: windows-latest }
-          - { name: macos-python3.7-minimum    , requirements: minimum,  python-ver: "3.7" , os: macos-13 }
-          - { name: macos-python3.12           , requirements: pinned ,  python-ver: "3.12", os: macos-latest }
+          - { name: linux-python3.10-minimum   , requirements: minimum,  python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.14           , requirements: pinned ,  python-ver: "3.14", os: ubuntu-latest }
+          - { name: windows-python3.10-minimum , requirements: minimum,  python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.14         , requirements: pinned ,  python-ver: "3.14", os: windows-latest }
+          - { name: macos-python3.10-minimum   , requirements: minimum,  python-ver: "3.10", os: macos-13 }
+          - { name: macos-python3.14           , requirements: pinned ,  python-ver: "3.14", os: macos-latest }
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45,<65", "setuptools_scm[toml]>=6.2", "cython>=3.0.10"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "cython>=3.0.10"]
+requires = ["setuptools>=45,<65", "setuptools_scm[toml]>=6.2", "cython>=3.0.10"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "cython>=3.0.10"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -44,7 +44,7 @@ dependencies = [
     "numpy>=1.21",
     "scikit-learn>=1",
 ]
-version = "0.2.0"
+version = "0.3.0"
 # dynamic = ["version"]
 
 [project.urls]

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,4 +1,4 @@
 # minimum versions of package dependencies for installing HDMF-AI, used in testing
 hdmf==3.5.1
-numpy==1.21
+numpy==1.22
 scikit-learn==1.0

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,4 +1,4 @@
 # minimum versions of package dependencies for installing HDMF-AI, used in testing
 hdmf==3.5.1
-numpy==1.22
+numpy==1.21
 scikit-learn==1.0

--- a/src/hdmf_ai/results_table.py
+++ b/src/hdmf_ai/results_table.py
@@ -454,3 +454,35 @@ class ResultsTable(_AutoGenResultsTable):
         # `n_dims` kwarg is passed into `__add_col` and will be read as the length of the second dimension
         # of the data only if the `data` kwarg is None.
         return self.__add_col(EmbeddedValues, **kwargs)
+
+    @docval(
+        {
+            "name": "data",
+            "type": ("array_data", "data"),
+            "doc": "Embedding (float) of each sample.",
+            "default": None,
+        },
+        {
+            "name": "description",
+            "type": str,
+            "doc": "A description for this column.",
+            "default": "A column to store embeddings, e.g., from dimensionality reduction, for each sample.",
+        },
+        {
+            "name": "n_dims",
+            "type": int,
+            "doc": (
+                "The number of dimensions in the embedding, "
+                "used to define the shape of the column only if data is None"
+            ),
+            "default": None,
+        },
+    )
+    def add_viz_embedding(self, **kwargs):
+        """Add embedding (a.k.a. transformation or representation) of each sample."""
+        kwargs["name"] = "viz_embedding"
+        kwargs["dtype"] = float
+        kwargs["dim2_kwarg"] = "n_dims"
+        # `n_dims` kwarg is passed into `__add_col` and will be read as the length of the second dimension
+        # of the data only if the `data` kwarg is None.
+        return self.__add_col(EmbeddedValues, **kwargs)

--- a/src/hdmf_ai/schema/results_table.yaml
+++ b/src/hdmf_ai/schema/results_table.yaml
@@ -185,4 +185,8 @@ groups:
     data_type_inc: EmbeddedValues
     doc: A column to store embeddings, e.g., from dimensionality reduction, for each sample.
     quantity: '?'
+  - name: viz_embedding
+    data_type_inc: EmbeddedValues
+    doc: A column to store embeddings meant for visualization.
+    quantity: '?'
 

--- a/tests/test_results_table.py
+++ b/tests/test_results_table.py
@@ -122,6 +122,12 @@ class ResultsTableTest(TestCase):
         with self.get_hdf5io() as io:
             io.write(rt)
 
+    def test_add_viz_embedding(self):
+        rt = ResultsTable(name="foo", description="a test results table")
+        rt.add_viz_embedding([[1.1, 2.9], [1.2, 2.8], [1.3, 2.7], [1.4, 2.6], [1.5, 2.5]])
+        with self.get_hdf5io() as io:
+            io.write(rt)
+
     def test_add_topk_classes(self):
         rt = ResultsTable(name="foo", description="a test results table")
         rt.add_topk_classes([[1, 2], [3, 4], [5, 6], [7, 8], [9, 0]])


### PR DESCRIPTION
## Motivation

It would be convenient to be able to store 2D or 3D embeddings meant for visualization alongside other AI outputs

## How to test the behavior?
```python
rt = ResultsTable(name="foo", description="a test results table")
rt.add_viz_embedding([[1.1, 2.9], [1.2, 2.8], [1.3, 2.7], [1.4, 2.6], [1.5, 2.5]])
```

## Checklist

- [ ] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our [Contributing Guide](https://github.com/hdmf-dev/hdmf-ai/blob/main/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?